### PR TITLE
fix(physics): balance graph manager refs

### DIFF
--- a/include/RE/bs_intrusive_ref_ptr.h
+++ b/include/RE/bs_intrusive_ref_ptr.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <Windows.h>
+
+#include <cstdint>
+#include <type_traits>
+#include <utility>
+
+// SKSE VR's legacy BSTSmartPointer is layout-only and does not decrement
+// BSIntrusiveRefCounted references. Use this owner for engine APIs that AddRef
+// an output parameter. It deliberately stays pointer-sized so it is ABI
+// compatible with the engine's output wrapper.
+template <class T, std::size_t RefCountOffset>
+class BSIntrusiveRefPtr
+{
+public:
+    T *ptr{ nullptr };
+
+    BSIntrusiveRefPtr() noexcept = default;
+    BSIntrusiveRefPtr(const BSIntrusiveRefPtr &) = delete;
+    BSIntrusiveRefPtr &operator=(const BSIntrusiveRefPtr &) = delete;
+
+    BSIntrusiveRefPtr(BSIntrusiveRefPtr &&other) noexcept :
+        ptr(std::exchange(other.ptr, nullptr))
+    {}
+
+    BSIntrusiveRefPtr &operator=(BSIntrusiveRefPtr &&other) noexcept
+    {
+        if (this != &other) {
+            Reset();
+            ptr = std::exchange(other.ptr, nullptr);
+        }
+        return *this;
+    }
+
+    ~BSIntrusiveRefPtr()
+    {
+        Reset();
+    }
+
+    void Reset() noexcept
+    {
+        T *object = std::exchange(ptr, nullptr);
+        auto *refCount = object ? reinterpret_cast<volatile LONG *>(
+            reinterpret_cast<std::uintptr_t>(object) + RefCountOffset) : nullptr;
+        if (object && InterlockedDecrement(refCount) == 0) {
+            using Destruct = void(*)(T *, std::uint32_t);
+            auto *vtable = *reinterpret_cast<std::uintptr_t **>(object);
+            reinterpret_cast<Destruct>(vtable[0])(object, 1);
+        }
+    }
+};

--- a/include/RE/havok_behavior.h
+++ b/include/RE/havok_behavior.h
@@ -997,12 +997,21 @@ inline hkbGeneratorOutput::TrackHeader *GetTrackHeader(hkbGeneratorOutput &gener
 
 typedef bool(*_IAnimationGraphManagerHolder_GetAnimationGraphManagerImpl)(IAnimationGraphManagerHolder *_this, BSAnimationGraphManagerPtr &a_out);
 inline bool GetAnimationGraphManager(Actor *actor, BSAnimationGraphManagerPtr &out) {
-    // Some callers intentionally reuse the same local for a second query.
-    // Release the previous result before Skyrim overwrites it.
-    out.Reset();
     IAnimationGraphManagerHolder *animGraphManagerHolder = &actor->animGraphHolder;
     UInt64 *vtbl = *((UInt64 **)animGraphManagerHolder);
-    return ((_IAnimationGraphManagerHolder_GetAnimationGraphManagerImpl)(vtbl[0x02]))(animGraphManagerHolder, out);
+
+    // Query into empty storage so correctness does not depend on how Skyrim
+    // treats a pre-populated output. Preserve the existing owner when Skyrim
+    // returns the same manager, dropping only the newly acquired reference.
+    BSAnimationGraphManagerPtr next;
+    const bool result = ((_IAnimationGraphManagerHolder_GetAnimationGraphManagerImpl)(vtbl[0x02]))(animGraphManagerHolder, next);
+    if (result && out.ptr == next.ptr) {
+        next.Reset();
+    }
+    else {
+        out = std::move(next);
+    }
+    return result;
 }
 
 void MapHighResPoseLocalToLowResPoseWorld(hkbRagdollDriver *driver, const hkQsTransform &worldFromModel, const hkQsTransform *highResPoseLocal, hkQsTransform *lowResPoseWorldOut, bool applyRigidBodyT = true);

--- a/include/RE/havok_behavior.h
+++ b/include/RE/havok_behavior.h
@@ -26,6 +26,7 @@
 #include "skse64/GameReferences.h"
 
 #include "RE/havok.h"
+#include "RE/bs_intrusive_ref_ptr.h"
 #include "RE/misc.h"
 #include "havok_ref_ptr.h"
 
@@ -773,6 +774,12 @@ public:
 static_assert(offsetof(BSAnimationGraphManager, graphs) == 0x40);
 static_assert(offsetof(BSAnimationGraphManager, updateLock) == 0x98);
 
+using BSAnimationGraphManagerPtr = BSIntrusiveRefPtr<BSAnimationGraphManager, 0x08>;
+static_assert(sizeof(BSAnimationGraphManagerPtr) == sizeof(void *));
+static_assert(alignof(BSAnimationGraphManagerPtr) == alignof(void *));
+static_assert(!std::is_copy_constructible_v<BSAnimationGraphManagerPtr>);
+static_assert(std::is_nothrow_move_constructible_v<BSAnimationGraphManagerPtr>);
+
 struct hkbPoweredRagdollControlData
 {
     HK_ALIGN16(hkReal m_maxForce) = 50.f; // 00
@@ -988,8 +995,11 @@ inline hkbGeneratorOutput::TrackHeader *GetTrackHeader(hkbGeneratorOutput &gener
     return numTracks > trackId ? &(generatorOutput.m_tracks->m_trackHeaders[trackId]) : nullptr;
 }
 
-typedef bool(*_IAnimationGraphManagerHolder_GetAnimationGraphManagerImpl)(IAnimationGraphManagerHolder *_this, BSTSmartPointer<BSAnimationGraphManager> &a_out);
-inline bool GetAnimationGraphManager(Actor *actor, BSTSmartPointer<BSAnimationGraphManager> &out) {
+typedef bool(*_IAnimationGraphManagerHolder_GetAnimationGraphManagerImpl)(IAnimationGraphManagerHolder *_this, BSAnimationGraphManagerPtr &a_out);
+inline bool GetAnimationGraphManager(Actor *actor, BSAnimationGraphManagerPtr &out) {
+    // Some callers intentionally reuse the same local for a second query.
+    // Release the previous result before Skyrim overwrites it.
+    out.Reset();
     IAnimationGraphManagerHolder *animGraphManagerHolder = &actor->animGraphHolder;
     UInt64 *vtbl = *((UInt64 **)animGraphManagerHolder);
     return ((_IAnimationGraphManagerHolder_GetAnimationGraphManagerImpl)(vtbl[0x02]))(animGraphManagerHolder, out);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include <deque>
 #include <optional>
 #include <shared_mutex>
+#include <new>
 
 #include <Physics/Collide/Shape/Convex/ConvexVertices/hkpConvexVerticesShape.h>
 #include <Physics/Collide/Shape/Convex/Capsule/hkpCapsuleShape.h>
@@ -280,7 +281,7 @@ void UpdateCollisionFilterOnAllBones(Actor *actor)
     if (Actor_IsInRagdollState(actor)) return;
 
     bool hasRagdollInterface = false;
-    BSTSmartPointer<BSAnimationGraphManager> animGraphManager{ 0 }; // need to init this to 0 or we crash
+    BSAnimationGraphManagerPtr animGraphManager;
     if (GetAnimationGraphManager(actor, animGraphManager)) {
         BSAnimationGraphManager_HasRagdoll(animGraphManager.ptr, &hasRagdollInterface);
     }
@@ -3078,11 +3079,19 @@ void TryUpdateNPCState(Actor *actor, bool isShoved, bool wasJustRagdolled)
 
 hkaKeyFrameHierarchyUtility::Output g_stressOut[200]; // set in a hook during driveToPose(). Just reserve a bunch of space so it can handle any number of bones.
 
-hkArray<hkVector4> g_scratchHkArray{}; // We can't call the destructor of this ourselves, so this is a global array to be used at will and never deallocated.
+// Construct the scratch array in static storage but intentionally never destroy
+// it: Skyrim/Havok grows it, and DLL shutdown must not free game-owned memory.
+alignas(hkArray<hkVector4>) char g_scratchHkArrayStorage[sizeof(hkArray<hkVector4>)]{};
+
+hkArray<hkVector4> &GetScratchHkArray()
+{
+    static auto *scratch = ::new (g_scratchHkArrayStorage) hkArray<hkVector4>{};
+    return *scratch;
+}
 
 bool IsAddedToWorld(Actor *actor)
 {
-    BSTSmartPointer<BSAnimationGraphManager> animGraphManager{ 0 };
+    BSAnimationGraphManagerPtr animGraphManager;
     if (!GetAnimationGraphManager(actor, animGraphManager)) return false;
 
     BSAnimationGraphManager *manager = animGraphManager.ptr;
@@ -3129,7 +3138,7 @@ bool IsAddableToWorld(Actor *actor)
 
     if (IsTemporaryIgnoredActor(actor)) return false;
 
-    BSTSmartPointer<BSAnimationGraphManager> animGraphManager{ 0 };
+    BSAnimationGraphManagerPtr animGraphManager;
     if (!GetAnimationGraphManager(actor, animGraphManager)) return false;
 
     BSAnimationGraphManager *manager = animGraphManager.ptr;
@@ -3440,7 +3449,7 @@ bool AddRagdollToWorld(Actor *actor)
     if (!Config::options.processRagdolledActors && Actor_IsInRagdollState(actor)) return false;
 
     bool hasRagdollInterface = false;
-    BSTSmartPointer<BSAnimationGraphManager> animGraphManager{ 0 }; // need to init this to 0 or we crash
+    BSAnimationGraphManagerPtr animGraphManager;
     if (GetAnimationGraphManager(actor, animGraphManager)) {
         BSAnimationGraphManager_HasRagdoll(animGraphManager.ptr, &hasRagdollInterface);
     }
@@ -3535,7 +3544,7 @@ bool AddRagdollToWorld(Actor *actor)
 
 void CleanupActiveRagdollTracking(Actor *actor)
 {
-    BSTSmartPointer<BSAnimationGraphManager> animGraphManager{ 0 }; // need to init this to 0 or we crash
+    BSAnimationGraphManagerPtr animGraphManager;
     if (GetAnimationGraphManager(actor, animGraphManager)) {
         BSAnimationGraphManager *manager = animGraphManager.ptr;
         {
@@ -3576,7 +3585,7 @@ bool RemoveRagdollFromWorld(Actor *actor)
     if (!Config::options.processRagdolledActors && isInRagdollState) return false;
 
     bool hasRagdollInterface = false;
-    BSTSmartPointer<BSAnimationGraphManager> animGraphManager{ 0 }; // need to init this to 0 or we crash
+    BSAnimationGraphManagerPtr animGraphManager;
     if (GetAnimationGraphManager(actor, animGraphManager)) {
         BSAnimationGraphManager_HasRagdoll(animGraphManager.ptr, &hasRagdollInterface);
     }
@@ -3607,7 +3616,7 @@ void DisableOrEnableSyncOnUpdate(Actor *actor, bool disableElseEnable)
     if (Actor_IsInRagdollState(actor)) return;
 
     bool hasRagdollInterface = false;
-    BSTSmartPointer<BSAnimationGraphManager> animGraphManager{ 0 }; // need to init this to 0 or we crash
+    BSAnimationGraphManagerPtr animGraphManager;
     if (GetAnimationGraphManager(actor, animGraphManager)) {
         BSAnimationGraphManager_HasRagdoll(animGraphManager.ptr, &hasRagdollInterface);
     }
@@ -3646,7 +3655,7 @@ void RemoveActorFromWorldIfActive(Actor *actor)
 void EnableGravity(Actor *actor)
 {
     bool hasRagdollInterface = false;
-    BSTSmartPointer<BSAnimationGraphManager> animGraphManager{ 0 }; // need to init this to 0 or we crash
+    BSAnimationGraphManagerPtr animGraphManager;
     if (GetAnimationGraphManager(actor, animGraphManager)) {
         BSAnimationGraphManager_HasRagdoll(animGraphManager.ptr, &hasRagdollInterface);
     }
@@ -4452,8 +4461,8 @@ void ProcessHavokHitJobsHook(HavokHitJobs *havokHitJobs)
 
                 if (Config::options.resizePlayerCharController && convexVerticesShape) {
                     // Shrink convex charcontroller shape
-                    g_scratchHkArray.clear();
-                    hkArray<hkVector4> &verts = g_scratchHkArray;
+                    hkArray<hkVector4> &verts = GetScratchHkArray();
+                    verts.clear();
 
                     hkpConvexVerticesShape_getOriginalVertices(convexVerticesShape, verts);
 
@@ -5777,7 +5786,7 @@ struct RemoveNonRagdollRigidBodiesFromWorldTask : TaskDelegate
         NiPointer<TESObjectREFR> refr;
         if (LookupREFRByHandle(handle, refr)) {
             if (Actor *actor = DYNAMIC_CAST(refr, TESObjectREFR, Actor)) {
-                BSTSmartPointer<BSAnimationGraphManager> animGraphManager{ 0 };
+                BSAnimationGraphManagerPtr animGraphManager;
                 if (GetAnimationGraphManager(actor, animGraphManager)) {
                     BSAnimationGraphManager *manager = animGraphManager.ptr;
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -735,7 +735,7 @@ void ForEachRagdollDriver(BSAnimationGraphManager *graphManager, std::function<v
 
 void ForEachRagdollDriver(Actor *actor, std::function<void(hkbRagdollDriver *)> f)
 {
-    BSTSmartPointer<BSAnimationGraphManager> animGraphManager{ 0 };
+    BSAnimationGraphManagerPtr animGraphManager;
     if (GetAnimationGraphManager(actor, animGraphManager)) {
         ForEachRagdollDriver(animGraphManager.ptr, f);
     }
@@ -752,7 +752,7 @@ void ForEachAnimationGraph(BSAnimationGraphManager *graphManager, std::function<
 
 void ForEachAnimationGraph(Actor *actor, std::function<void(BShkbAnimationGraph *)> f)
 {
-    BSTSmartPointer<BSAnimationGraphManager> animGraphManager{ 0 };
+    BSAnimationGraphManagerPtr animGraphManager;
     if (GetAnimationGraphManager(actor, animGraphManager)) {
         ForEachAnimationGraph(animGraphManager.ptr, f);
     }


### PR DESCRIPTION
## Why

Skyrim VR's animation-graph-manager getter increments the returned manager's
reference count. The legacy SKSEVR smart pointer used here is pointer-only and
does not automatically balance that acquired reference. PLANCK call sites
therefore accumulated manager references during ordinary cell transitions.

A hardware-watchpoint capture over 5.0027 seconds observed 20,997 increments
across 37 managers. PLANCK's four mapped call sites accounted for 25,702
sampled caller hits in the capture; unlike the comparison caller, those paths
had no matching decrement at function exit. Unpatched manager counts reached
11,614.

## What changed

- Add a pointer-sized, move-only owner for the reference returned by Skyrim's
  virtual getter.
- Atomically release that reference at scope exit and invoke the target's
  deleting destructor only on the final release.
- Query into an empty temporary owner rather than passing reused storage to
  undocumented overwrite behavior.
- If Skyrim returns the same manager, preserve the existing owner and release
  only the getter's additional reference; otherwise move the replacement into
  the caller and release the prior owner.
- Convert PLANCK's animation-manager call sites to the owning wrapper.

The unrelated Havok scratch-array lifetime change that existed in an earlier
downstream package is intentionally excluded from this focused PR.

## Ownership and ABI basis

The target layout places `BSIntrusiveRefCounted` at manager object offset
`0x08`, where its 32-bit count is updated atomically. The virtual getter takes
an owning `BSTSmartPointer<BSAnimationGraphManager>&`; assignment acquires the
result, and final release uses the manager's virtual deleting destructor at
slot zero. The replacement owner remains one pointer wide and is passed at the
same ABI position as the legacy wrapper.

## Validation

- Exact-head x64 Release `ClCompile` passed with Skyrim VR 1.4.15, SKSEVR,
  MSVC v145, and the locally available Havok SDK before this scope-only cleanup.
- ABI assertions for the pointer wrapper and graph-manager locations pass.
- `git diff --check` passes on the rebased head.
- With the prior explicit-owner implementation, a Riften -> Markarth ->
  Riften A/B run ended with 109 managers: 108 at reference count 1 and one at
  count 2. Of the prior population, 110 managers departed and 99 new managers
  appeared, with no accumulating-reference pattern.
- The empty-temporary refinement preserves the same net ownership rules and
  passed exact-head compilation. It has not received a separate runtime pass.

The latest update rebases onto current upstream (including PR #5) and removes
only the unrelated scratch-array change; it does not alter the reviewed
manager ownership implementation.
