### PR TITLE
fix(physics): preserve collision alpha state

### DIFF
--- a/include/RE/misc.h
+++ b/include/RE/misc.h
@@ -949,6 +949,5 @@ typedef void (*_bhkWorld_dtor)(bhkWorld *);
 typedef void(*_ActorState_GetActorRotationEuler)(ActorState *actorState, NiPoint3 &outEuler); // 4
 typedef float(*_ActorState_GetRotationSpeedZ)(ActorState *actorState); // 6
 typedef void(*_Actor_SetAlpha)(Actor *actor, float alpha); // E3
-typedef float(*_Actor_GetAlpha)(Actor *actor); // E4
 typedef void(*_NiNode_SetAt2)(NiNode *node, UInt32 index, NiAVObject *child);
 

--- a/include/RE/misc.h
+++ b/include/RE/misc.h
@@ -949,5 +949,6 @@ typedef void (*_bhkWorld_dtor)(bhkWorld *);
 typedef void(*_ActorState_GetActorRotationEuler)(ActorState *actorState, NiPoint3 &outEuler); // 4
 typedef float(*_ActorState_GetRotationSpeedZ)(ActorState *actorState); // 6
 typedef void(*_Actor_SetAlpha)(Actor *actor, float alpha); // E3
+typedef float(*_Actor_GetAlpha)(Actor *actor); // E4
 typedef void(*_NiNode_SetAt2)(NiNode *node, UInt32 index, NiAVObject *child);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2539,6 +2539,107 @@ struct ActorAlphaData
 };
 std::unordered_map<Actor *, ActorAlphaData> g_dontCollideUntilStoppedCollidingActorAlphas{};
 
+// Actor::SetAlpha walks the actor's scene graph and mutates shader properties.
+// The player-proxy manifold callback may run during Havok's multithreaded update,
+// so defer that work to SKSE task processing outside the callback.
+std::unordered_map<UInt32, ActorAlphaData> g_actorCollisionAlphaOverrides{};
+
+// The inherited VR headers label actor vtable entry E4 as a float-returning
+// GetAlpha, but that signature is not valid in Skyrim VR 1.4.15. Calling it can
+// leave an unrelated XMM value in the result and feed an enormous value to
+// Actor::SetAlpha. MiddleProcess::actorAlpha is the authoritative process
+// baseline. SetAlpha changes the render graph without updating this field, so
+// restoration must apply the current process baseline directly.
+bool TryGetActorAlpha(Actor *actor, float &alpha)
+{
+    if (!actor || !actor->processManager || !actor->processManager->middleProcess) {
+        return false;
+    }
+
+    alpha = actor->processManager->middleProcess->actorAlpha;
+    return alpha >= 0.f && alpha <= 3.f; // Normal 0..1, optionally +2 for no fade.
+}
+
+struct UpdateActorCollisionAlphaTask : TaskDelegate
+{
+    enum class Action : UInt8
+    {
+        Apply,
+        Restore
+    };
+
+    UpdateActorCollisionAlphaTask(UInt32 a_actorHandle, Action a_action)
+        : actorHandle(a_actorHandle), action(a_action) {}
+
+    static UpdateActorCollisionAlphaTask *Create(UInt32 a_actorHandle, Action a_action)
+    {
+        return new UpdateActorCollisionAlphaTask(a_actorHandle, a_action);
+    }
+
+    virtual void Run() override
+    {
+        if (action == Action::Restore) {
+            auto overrideIt = g_actorCollisionAlphaOverrides.find(actorHandle);
+            if (overrideIt == g_actorCollisionAlphaOverrides.end()) {
+                return;
+            }
+
+            NiPointer<TESObjectREFR> refr;
+            if (LookupREFRByHandle(actorHandle, refr)) {
+                if (Actor *actor = DYNAMIC_CAST(refr, TESObjectREFR, Actor)) {
+                    float processAlpha = -1.f;
+                    const float restoreAlpha = TryGetActorAlpha(actor, processAlpha)
+                        ? processAlpha
+                        : overrideIt->second.originalAlpha;
+                    get_vfunc<_Actor_SetAlpha>(actor, 0xE3)(actor, restoreAlpha);
+                }
+            }
+            g_actorCollisionAlphaOverrides.erase(overrideIt);
+            return;
+        }
+
+        if (g_actorCollisionAlphaOverrides.find(actorHandle) != g_actorCollisionAlphaOverrides.end()) {
+            return;
+        }
+
+        NiPointer<TESObjectREFR> refr;
+        if (!LookupREFRByHandle(actorHandle, refr)) {
+            return;
+        }
+        Actor *actor = DYNAMIC_CAST(refr, TESObjectREFR, Actor);
+        if (!actor) {
+            return;
+        }
+
+        float currentAlpha = -1.f;
+        if (!TryGetActorAlpha(actor, currentAlpha)) {
+            _MESSAGE("[CollisionAlpha] Invalid process alpha for actor %08X: %g", actor->formID, currentAlpha);
+            return;
+        }
+
+        float newAlpha = currentAlpha * Config::options.playerActorCollisionPhaseThroughAlphaMult;
+        if (currentAlpha >= 2.f) { // The game uses +2 alpha to signify no fade in/out.
+            newAlpha = 2.f + ((currentAlpha - 2.f) * Config::options.playerActorCollisionPhaseThroughAlphaMult);
+        }
+
+        if (newAlpha < 0.f || newAlpha > 3.f) {
+            _MESSAGE("[CollisionAlpha] Invalid target alpha for actor %08X: %g", actor->formID, newAlpha);
+            return;
+        }
+
+        get_vfunc<_Actor_SetAlpha>(actor, 0xE3)(actor, newAlpha);
+        g_actorCollisionAlphaOverrides.emplace(actorHandle, ActorAlphaData{ currentAlpha, newAlpha });
+    }
+
+    virtual void Dispose() override
+    {
+        delete this;
+    }
+
+    UInt32 actorHandle;
+    Action action;
+};
+
 std::unordered_set<Actor *> g_dontCollideUntilStoppedCollidingActors{};
 std::unordered_set<TESObjectREFR *> g_dontCollideActors{};
 std::mutex g_dontCollideActorsLock{};
@@ -6970,6 +7071,13 @@ void ahkpCharacterProxy_updateManifold_Hook(hkpCharacterProxy *proxy, hkpAllCdPo
         g_clearUpdateManifoldObjects = false;
 
         g_dontCollideUntilStoppedCollidingActors.clear();
+        for (auto &entry : g_dontCollideUntilStoppedCollidingActorAlphas) {
+            if (g_taskInterface) {
+                g_taskInterface->AddTask(UpdateActorCollisionAlphaTask::Create(
+                    GetOrCreateRefrHandle(entry.first),
+                    UpdateActorCollisionAlphaTask::Action::Restore));
+            }
+        }
         g_dontCollideUntilStoppedCollidingActorAlphas.clear();
 
         {
@@ -7055,15 +7163,14 @@ void ahkpCharacterProxy_updateManifold_Hook(hkpCharacterProxy *proxy, hkpAllCdPo
                             bool removeBecauseDontCollide = g_dontCollideUntilStoppedCollidingActors.find(actor) != g_dontCollideUntilStoppedCollidingActors.end();
 
                             if (removeBecauseDontCollide) {
-                                float currentAlpha = get_vfunc<_Actor_GetAlpha>(actor, 0xE4)(actor);
-                                float newAlpha = currentAlpha * Config::options.playerActorCollisionPhaseThroughAlphaMult;
-                                if (currentAlpha >= 2.f) { // game uses +2 alpha to signify no fade in/out
-                                    newAlpha = 2.f + ((currentAlpha - 2.f) * Config::options.playerActorCollisionPhaseThroughAlphaMult);
-                                }
                                 auto it = g_dontCollideUntilStoppedCollidingActorAlphas.find(actor);
                                 if (it == g_dontCollideUntilStoppedCollidingActorAlphas.end()) {
-                                    get_vfunc<_Actor_SetAlpha>(actor, 0xE3)(actor, newAlpha);
-                                    g_dontCollideUntilStoppedCollidingActorAlphas.emplace(actor, ActorAlphaData{ currentAlpha, newAlpha });
+                                    if (g_taskInterface) {
+                                        g_taskInterface->AddTask(UpdateActorCollisionAlphaTask::Create(
+                                            refrHandle,
+                                            UpdateActorCollisionAlphaTask::Action::Apply));
+                                        g_dontCollideUntilStoppedCollidingActorAlphas.emplace(actor, ActorAlphaData{});
+                                    }
                                 }
                                 g_physicsListener.IgnoreCollisionForSeconds(false, actor, *g_deltaTime * 2.f);
                                 g_physicsListener.IgnoreCollisionForSeconds(true, actor, *g_deltaTime * 2.f);
@@ -7120,9 +7227,10 @@ void ahkpCharacterProxy_updateManifold_Hook(hkpCharacterProxy *proxy, hkpAllCdPo
 
                         auto it = g_dontCollideUntilStoppedCollidingActorAlphas.find(actor);
                         if (it != g_dontCollideUntilStoppedCollidingActorAlphas.end()) {
-                            float currentAlpha = get_vfunc<_Actor_GetAlpha>(actor, 0xE4)(actor);
-                            if (currentAlpha == it->second.overriddenAlpha) {
-                                get_vfunc<_Actor_SetAlpha>(actor, 0xE3)(actor, it->second.originalAlpha);
+                            if (g_taskInterface) {
+                                g_taskInterface->AddTask(UpdateActorCollisionAlphaTask::Create(
+                                    actorHandle,
+                                    UpdateActorCollisionAlphaTask::Action::Restore));
                             }
                             g_dontCollideUntilStoppedCollidingActorAlphas.erase(it);
                         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2538,26 +2538,56 @@ struct ActorAlphaData
     float originalAlpha;
     float overriddenAlpha;
 };
-std::unordered_map<Actor *, ActorAlphaData> g_dontCollideUntilStoppedCollidingActorAlphas{};
+
+enum class ActorAlphaEpisodeState : UInt8
+{
+    PendingApply,
+    Applying,
+    Applied,
+    Rejected,
+    Retired
+};
+
+constexpr UInt8 kActorAlphaMaxApplyAttempts = 3;
+constexpr UInt32 kActorAlphaRetryFrames = 30;
+
+// Retain the actor for the complete phase-through episode and every queued task.
+// Atomic state distinguishes rejected work from a successfully applied override.
+struct ActorAlphaEpisode
+{
+    ActorAlphaEpisode(UInt32 a_actorHandle, const NiPointer<TESObjectREFR>& a_actorReference,
+        UInt32 a_queuedFrame)
+        : actorHandle(a_actorHandle), actorReference(a_actorReference), lastQueuedFrame(a_queuedFrame) {}
+
+    UInt32 actorHandle;
+    NiPointer<TESObjectREFR> actorReference;
+    std::atomic<ActorAlphaEpisodeState> state{ ActorAlphaEpisodeState::PendingApply };
+    std::mutex taskLock;
+    UInt32 lastQueuedFrame;
+    UInt8 attempts{ 1 };
+};
+
+std::unordered_map<UInt32, std::shared_ptr<ActorAlphaEpisode>> g_dontCollideUntilStoppedCollidingActorAlphas{};
 
 // Actor::SetAlpha walks the actor's scene graph and mutates shader properties.
 // The player-proxy manifold callback may run during Havok's multithreaded update,
-// so keep the complete GetAlpha / SetAlpha transaction on the SKSE task queue.
+// so defer that work to SKSE task processing outside the callback.
 std::unordered_map<UInt32, ActorAlphaData> g_actorCollisionAlphaOverrides{};
 
-bool IsValidActorAlpha(float alpha)
-{
-    return std::isfinite(alpha) && alpha >= 0.f && alpha <= 3.f; // Normal 0..1, optionally +2 for no fade.
-}
-
+// The inherited VR headers label actor vtable entry E4 as a float-returning
+// GetAlpha, but that signature is not valid in Skyrim VR 1.4.15. Calling it can
+// leave an unrelated XMM value in the result and feed an enormous value to
+// Actor::SetAlpha. MiddleProcess::actorAlpha is the authoritative process
+// baseline. SetAlpha changes the render graph without updating this field, so
+// restoration must apply the current process baseline directly.
 bool TryGetActorAlpha(Actor *actor, float &alpha)
 {
-    if (!actor) {
+    if (!actor || !actor->processManager || !actor->processManager->middleProcess) {
         return false;
     }
 
-    alpha = get_vfunc<_Actor_GetAlpha>(actor, 0xE4)(actor);
-    return IsValidActorAlpha(alpha);
+    alpha = actor->processManager->middleProcess->actorAlpha;
+    return alpha >= 0.f && alpha <= 3.f; // Normal 0..1, optionally +2 for no fade.
 }
 
 struct UpdateActorCollisionAlphaTask : TaskDelegate
@@ -2568,62 +2598,58 @@ struct UpdateActorCollisionAlphaTask : TaskDelegate
         Restore
     };
 
-    UpdateActorCollisionAlphaTask(UInt32 a_actorHandle, Action a_action)
-        : actorHandle(a_actorHandle), action(a_action) {}
+    UpdateActorCollisionAlphaTask(std::shared_ptr<ActorAlphaEpisode> a_episode, Action a_action)
+        : episode(std::move(a_episode)), action(a_action) {}
 
-    static UpdateActorCollisionAlphaTask *Create(UInt32 a_actorHandle, Action a_action)
+    static UpdateActorCollisionAlphaTask *Create(
+        const std::shared_ptr<ActorAlphaEpisode>& a_episode, Action a_action)
     {
-        return new UpdateActorCollisionAlphaTask(a_actorHandle, a_action);
+        return new UpdateActorCollisionAlphaTask(a_episode, a_action);
     }
 
     virtual void Run() override
     {
+        std::scoped_lock lock(episode->taskLock);
+        const UInt32 actorHandle = episode->actorHandle;
         if (action == Action::Restore) {
             auto overrideIt = g_actorCollisionAlphaOverrides.find(actorHandle);
             if (overrideIt == g_actorCollisionAlphaOverrides.end()) {
                 return;
             }
 
-            NiPointer<TESObjectREFR> refr;
-            if (LookupREFRByHandle(actorHandle, refr)) {
-                if (Actor *actor = DYNAMIC_CAST(refr, TESObjectREFR, Actor)) {
-                    float currentAlpha = -1.f;
-                    if (!TryGetActorAlpha(actor, currentAlpha)) {
-                        _MESSAGE("[CollisionAlpha] Invalid alpha while restoring actor %08X: %g", actor->formID, currentAlpha);
-                    }
-                    else if (currentAlpha == overrideIt->second.overriddenAlpha) { // Only undo our own value.
-                        get_vfunc<_Actor_SetAlpha>(actor, 0xE3)(actor, overrideIt->second.originalAlpha);
-                    }
-                    else {
-                        _MESSAGE(
-                            "[CollisionAlpha] Actor %08X alpha changed externally; current=%g override=%g original=%g",
-                            actor->formID,
-                            currentAlpha,
-                            overrideIt->second.overriddenAlpha,
-                            overrideIt->second.originalAlpha);
-                    }
-                }
+            if (Actor *actor = DYNAMIC_CAST(episode->actorReference, TESObjectREFR, Actor)) {
+                float processAlpha = -1.f;
+                const float restoreAlpha = TryGetActorAlpha(actor, processAlpha)
+                    ? processAlpha
+                    : overrideIt->second.originalAlpha;
+                get_vfunc<_Actor_SetAlpha>(actor, 0xE3)(actor, restoreAlpha);
             }
             g_actorCollisionAlphaOverrides.erase(overrideIt);
             return;
         }
 
-        if (g_actorCollisionAlphaOverrides.find(actorHandle) != g_actorCollisionAlphaOverrides.end()) {
+        ActorAlphaEpisodeState expectedState = ActorAlphaEpisodeState::PendingApply;
+        if (!episode->state.compare_exchange_strong(expectedState, ActorAlphaEpisodeState::Applying)) {
             return;
         }
 
-        NiPointer<TESObjectREFR> refr;
-        if (!LookupREFRByHandle(actorHandle, refr)) {
+        if (g_actorCollisionAlphaOverrides.find(actorHandle) != g_actorCollisionAlphaOverrides.end()) {
+            episode->state.store(ActorAlphaEpisodeState::Applied);
             return;
         }
-        Actor *actor = DYNAMIC_CAST(refr, TESObjectREFR, Actor);
+
+        Actor *actor = DYNAMIC_CAST(episode->actorReference, TESObjectREFR, Actor);
         if (!actor) {
+            expectedState = ActorAlphaEpisodeState::Applying;
+            episode->state.compare_exchange_strong(expectedState, ActorAlphaEpisodeState::Rejected);
             return;
         }
 
         float currentAlpha = -1.f;
         if (!TryGetActorAlpha(actor, currentAlpha)) {
-            _MESSAGE("[CollisionAlpha] Invalid alpha for actor %08X: %g", actor->formID, currentAlpha);
+            _MESSAGE("[CollisionAlpha] Invalid process alpha for actor %08X: %g", actor->formID, currentAlpha);
+            expectedState = ActorAlphaEpisodeState::Applying;
+            episode->state.compare_exchange_strong(expectedState, ActorAlphaEpisodeState::Rejected);
             return;
         }
 
@@ -2632,13 +2658,20 @@ struct UpdateActorCollisionAlphaTask : TaskDelegate
             newAlpha = 2.f + ((currentAlpha - 2.f) * Config::options.playerActorCollisionPhaseThroughAlphaMult);
         }
 
-        if (!IsValidActorAlpha(newAlpha)) {
+        if (!(newAlpha >= 0.f && newAlpha <= 3.f)) {
             _MESSAGE("[CollisionAlpha] Invalid target alpha for actor %08X: %g", actor->formID, newAlpha);
+            expectedState = ActorAlphaEpisodeState::Applying;
+            episode->state.compare_exchange_strong(expectedState, ActorAlphaEpisodeState::Rejected);
             return;
         }
 
+        if (episode->state.load() != ActorAlphaEpisodeState::Applying) {
+            return;
+        }
         get_vfunc<_Actor_SetAlpha>(actor, 0xE3)(actor, newAlpha);
         g_actorCollisionAlphaOverrides.emplace(actorHandle, ActorAlphaData{ currentAlpha, newAlpha });
+        expectedState = ActorAlphaEpisodeState::Applying;
+        episode->state.compare_exchange_strong(expectedState, ActorAlphaEpisodeState::Applied);
     }
 
     virtual void Dispose() override
@@ -2646,7 +2679,7 @@ struct UpdateActorCollisionAlphaTask : TaskDelegate
         delete this;
     }
 
-    UInt32 actorHandle;
+    std::shared_ptr<ActorAlphaEpisode> episode;
     Action action;
 };
 
@@ -7082,9 +7115,10 @@ void ahkpCharacterProxy_updateManifold_Hook(hkpCharacterProxy *proxy, hkpAllCdPo
 
         g_dontCollideUntilStoppedCollidingActors.clear();
         for (auto &entry : g_dontCollideUntilStoppedCollidingActorAlphas) {
+            entry.second->state.store(ActorAlphaEpisodeState::Retired);
             if (g_taskInterface) {
                 g_taskInterface->AddTask(UpdateActorCollisionAlphaTask::Create(
-                    GetOrCreateRefrHandle(entry.first),
+                    entry.second,
                     UpdateActorCollisionAlphaTask::Action::Restore));
             }
         }
@@ -7173,13 +7207,28 @@ void ahkpCharacterProxy_updateManifold_Hook(hkpCharacterProxy *proxy, hkpAllCdPo
                             bool removeBecauseDontCollide = g_dontCollideUntilStoppedCollidingActors.find(actor) != g_dontCollideUntilStoppedCollidingActors.end();
 
                             if (removeBecauseDontCollide) {
-                                auto it = g_dontCollideUntilStoppedCollidingActorAlphas.find(actor);
+                                auto it = g_dontCollideUntilStoppedCollidingActorAlphas.find(refrHandle);
                                 if (it == g_dontCollideUntilStoppedCollidingActorAlphas.end()) {
                                     if (g_taskInterface) {
+                                        auto episode = std::make_shared<ActorAlphaEpisode>(
+                                            refrHandle, refr, *g_currentFrameCounter);
                                         g_taskInterface->AddTask(UpdateActorCollisionAlphaTask::Create(
-                                            refrHandle,
+                                            episode,
                                             UpdateActorCollisionAlphaTask::Action::Apply));
-                                        g_dontCollideUntilStoppedCollidingActorAlphas.emplace(actor, ActorAlphaData{});
+                                        g_dontCollideUntilStoppedCollidingActorAlphas.emplace(refrHandle, std::move(episode));
+                                    }
+                                }
+                                else if (it->second->state.load() == ActorAlphaEpisodeState::Rejected &&
+                                    it->second->attempts < kActorAlphaMaxApplyAttempts &&
+                                    *g_currentFrameCounter - it->second->lastQueuedFrame >= kActorAlphaRetryFrames) {
+                                    ActorAlphaEpisodeState rejected = ActorAlphaEpisodeState::Rejected;
+                                    if (it->second->state.compare_exchange_strong(
+                                        rejected, ActorAlphaEpisodeState::PendingApply)) {
+                                        it->second->attempts++;
+                                        it->second->lastQueuedFrame = *g_currentFrameCounter;
+                                        g_taskInterface->AddTask(UpdateActorCollisionAlphaTask::Create(
+                                            it->second,
+                                            UpdateActorCollisionAlphaTask::Action::Apply));
                                     }
                                 }
                                 g_physicsListener.IgnoreCollisionForSeconds(false, actor, *g_deltaTime * 2.f);
@@ -7230,28 +7279,30 @@ void ahkpCharacterProxy_updateManifold_Hook(hkpCharacterProxy *proxy, hkpAllCdPo
         if (collidingActorHandles.find(actorHandle) == collidingActorHandles.end()) {
             // Actor was colliding in the previous frame but not in the current frame
             UInt32 handle = actorHandle;
+            Actor *actor = nullptr;
             if (NiPointer<TESObjectREFR> refr; LookupREFRByHandle(handle, refr)) {
-                if (Actor *actor = DYNAMIC_CAST(refr, TESObjectREFR, Actor)) {
-                    if (g_dontCollideUntilStoppedCollidingActors.find(actor) != g_dontCollideUntilStoppedCollidingActors.end()) {
-                        g_dontCollideUntilStoppedCollidingActors.erase(actor);
+                actor = DYNAMIC_CAST(refr, TESObjectREFR, Actor);
+            }
 
-                        auto it = g_dontCollideUntilStoppedCollidingActorAlphas.find(actor);
-                        if (it != g_dontCollideUntilStoppedCollidingActorAlphas.end()) {
-                            if (g_taskInterface) {
-                                g_taskInterface->AddTask(UpdateActorCollisionAlphaTask::Create(
-                                    actorHandle,
-                                    UpdateActorCollisionAlphaTask::Action::Restore));
-                            }
-                            g_dontCollideUntilStoppedCollidingActorAlphas.erase(it);
-                        }
-                    }
+            auto alphaIt = g_dontCollideUntilStoppedCollidingActorAlphas.find(actorHandle);
+            if (alphaIt != g_dontCollideUntilStoppedCollidingActorAlphas.end()) {
+                if (!actor) {
+                    actor = DYNAMIC_CAST(alphaIt->second->actorReference, TESObjectREFR, Actor);
+                }
+                alphaIt->second->state.store(ActorAlphaEpisodeState::Retired);
+                if (g_taskInterface) {
+                    g_taskInterface->AddTask(UpdateActorCollisionAlphaTask::Create(
+                        alphaIt->second,
+                        UpdateActorCollisionAlphaTask::Action::Restore));
+                }
+                g_dontCollideUntilStoppedCollidingActorAlphas.erase(alphaIt);
+            }
 
-                    {
-                        std::scoped_lock lock(g_dontCollideActorsLock);
-                        if (g_dontCollideActors.find(actor) != g_dontCollideActors.end()) {
-                            g_dontCollideActors.erase(actor);
-                        }
-                    }
+            if (actor) {
+                g_dontCollideUntilStoppedCollidingActors.erase(actor);
+                std::scoped_lock lock(g_dontCollideActorsLock);
+                if (g_dontCollideActors.find(actor) != g_dontCollideActors.end()) {
+                    g_dontCollideActors.erase(actor);
                 }
             }
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2533,12 +2533,6 @@ struct CollidedActorData
 };
 std::unordered_map<Actor *, CollidedActorData> g_collidedActorsPushAway{};
 
-struct ActorAlphaData
-{
-    float originalAlpha;
-    float overriddenAlpha;
-};
-
 enum class ActorAlphaEpisodeState : UInt8
 {
     PendingApply,
@@ -2567,12 +2561,20 @@ struct ActorAlphaEpisode
     UInt8 attempts{ 1 };
 };
 
+struct ActorAlphaData
+{
+    float originalAlpha;
+    float overriddenAlpha;
+    std::shared_ptr<ActorAlphaEpisode> owner;
+};
+
 std::unordered_map<UInt32, std::shared_ptr<ActorAlphaEpisode>> g_dontCollideUntilStoppedCollidingActorAlphas{};
 
 // Actor::SetAlpha walks the actor's scene graph and mutates shader properties.
 // The player-proxy manifold callback may run during Havok's multithreaded update,
 // so defer that work to SKSE task processing outside the callback.
 std::unordered_map<UInt32, ActorAlphaData> g_actorCollisionAlphaOverrides{};
+std::mutex g_actorCollisionAlphaOverridesLock{};
 
 // The inherited VR headers label actor vtable entry E4 as a float-returning
 // GetAlpha, but that signature is not valid in Skyrim VR 1.4.15. Calling it can
@@ -2612,8 +2614,10 @@ struct UpdateActorCollisionAlphaTask : TaskDelegate
         std::scoped_lock lock(episode->taskLock);
         const UInt32 actorHandle = episode->actorHandle;
         if (action == Action::Restore) {
+            std::scoped_lock overrideLock(g_actorCollisionAlphaOverridesLock);
             auto overrideIt = g_actorCollisionAlphaOverrides.find(actorHandle);
-            if (overrideIt == g_actorCollisionAlphaOverrides.end()) {
+            if (overrideIt == g_actorCollisionAlphaOverrides.end() ||
+                overrideIt->second.owner != episode) {
                 return;
             }
 
@@ -2630,11 +2634,6 @@ struct UpdateActorCollisionAlphaTask : TaskDelegate
 
         ActorAlphaEpisodeState expectedState = ActorAlphaEpisodeState::PendingApply;
         if (!episode->state.compare_exchange_strong(expectedState, ActorAlphaEpisodeState::Applying)) {
-            return;
-        }
-
-        if (g_actorCollisionAlphaOverrides.find(actorHandle) != g_actorCollisionAlphaOverrides.end()) {
-            episode->state.store(ActorAlphaEpisodeState::Applied);
             return;
         }
 
@@ -2668,8 +2667,18 @@ struct UpdateActorCollisionAlphaTask : TaskDelegate
         if (episode->state.load() != ActorAlphaEpisodeState::Applying) {
             return;
         }
+
+        std::scoped_lock overrideLock(g_actorCollisionAlphaOverridesLock);
+        if (episode->state.load() != ActorAlphaEpisodeState::Applying ||
+            g_actorCollisionAlphaOverrides.find(actorHandle) != g_actorCollisionAlphaOverrides.end()) {
+            expectedState = ActorAlphaEpisodeState::Applying;
+            episode->state.compare_exchange_strong(expectedState, ActorAlphaEpisodeState::Rejected);
+            return;
+        }
+
+        g_actorCollisionAlphaOverrides.emplace(
+            actorHandle, ActorAlphaData{ currentAlpha, newAlpha, episode });
         get_vfunc<_Actor_SetAlpha>(actor, 0xE3)(actor, newAlpha);
-        g_actorCollisionAlphaOverrides.emplace(actorHandle, ActorAlphaData{ currentAlpha, newAlpha });
         expectedState = ActorAlphaEpisodeState::Applying;
         episode->state.compare_exchange_strong(expectedState, ActorAlphaEpisodeState::Applied);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2572,24 +2572,25 @@ std::unordered_map<UInt32, std::shared_ptr<ActorAlphaEpisode>> g_dontCollideUnti
 
 // Actor::SetAlpha walks the actor's scene graph and mutates shader properties.
 // The player-proxy manifold callback may run during Havok's multithreaded update,
-// so defer that work to SKSE task processing outside the callback.
+// so keep the complete GetAlpha / SetAlpha transaction on the SKSE task queue.
 std::unordered_map<UInt32, ActorAlphaData> g_actorCollisionAlphaOverrides{};
 std::mutex g_actorCollisionAlphaOverridesLock{};
 
-// The inherited VR headers label actor vtable entry E4 as a float-returning
-// GetAlpha, but that signature is not valid in Skyrim VR 1.4.15. Calling it can
-// leave an unrelated XMM value in the result and feed an enormous value to
-// Actor::SetAlpha. MiddleProcess::actorAlpha is the authoritative process
-// baseline. SetAlpha changes the render graph without updating this field, so
-// restoration must apply the current process baseline directly.
+bool IsValidActorAlpha(float alpha)
+{
+    return std::isfinite(alpha) && alpha >= 0.f && alpha <= 3.f; // Normal 0..1, optionally +2 for no fade.
+}
+
+// E4 reads the same HighProcess::maxAlpha state that E3 updates. Treat that
+// value as externally shared: validate before use and only undo our own value.
 bool TryGetActorAlpha(Actor *actor, float &alpha)
 {
-    if (!actor || !actor->processManager || !actor->processManager->middleProcess) {
+    if (!actor) {
         return false;
     }
 
-    alpha = actor->processManager->middleProcess->actorAlpha;
-    return alpha >= 0.f && alpha <= 3.f; // Normal 0..1, optionally +2 for no fade.
+    alpha = get_vfunc<_Actor_GetAlpha>(actor, 0xE4)(actor);
+    return IsValidActorAlpha(alpha);
 }
 
 struct UpdateActorCollisionAlphaTask : TaskDelegate
@@ -2622,11 +2623,21 @@ struct UpdateActorCollisionAlphaTask : TaskDelegate
             }
 
             if (Actor *actor = DYNAMIC_CAST(episode->actorReference, TESObjectREFR, Actor)) {
-                float processAlpha = -1.f;
-                const float restoreAlpha = TryGetActorAlpha(actor, processAlpha)
-                    ? processAlpha
-                    : overrideIt->second.originalAlpha;
-                get_vfunc<_Actor_SetAlpha>(actor, 0xE3)(actor, restoreAlpha);
+                float currentAlpha = -1.f;
+                if (!TryGetActorAlpha(actor, currentAlpha)) {
+                    _MESSAGE("[CollisionAlpha] Invalid alpha while restoring actor %08X: %g", actor->formID, currentAlpha);
+                }
+                else if (currentAlpha == overrideIt->second.overriddenAlpha) { // Only undo our own value.
+                    get_vfunc<_Actor_SetAlpha>(actor, 0xE3)(actor, overrideIt->second.originalAlpha);
+                }
+                else {
+                    _MESSAGE(
+                        "[CollisionAlpha] Actor %08X alpha changed externally; current=%g override=%g original=%g",
+                        actor->formID,
+                        currentAlpha,
+                        overrideIt->second.overriddenAlpha,
+                        overrideIt->second.originalAlpha);
+                }
             }
             g_actorCollisionAlphaOverrides.erase(overrideIt);
             return;
@@ -2646,7 +2657,7 @@ struct UpdateActorCollisionAlphaTask : TaskDelegate
 
         float currentAlpha = -1.f;
         if (!TryGetActorAlpha(actor, currentAlpha)) {
-            _MESSAGE("[CollisionAlpha] Invalid process alpha for actor %08X: %g", actor->formID, currentAlpha);
+            _MESSAGE("[CollisionAlpha] Invalid alpha for actor %08X: %g", actor->formID, currentAlpha);
             expectedState = ActorAlphaEpisodeState::Applying;
             episode->state.compare_exchange_strong(expectedState, ActorAlphaEpisodeState::Rejected);
             return;
@@ -2657,7 +2668,7 @@ struct UpdateActorCollisionAlphaTask : TaskDelegate
             newAlpha = 2.f + ((currentAlpha - 2.f) * Config::options.playerActorCollisionPhaseThroughAlphaMult);
         }
 
-        if (!(newAlpha >= 0.f && newAlpha <= 3.f)) {
+        if (!IsValidActorAlpha(newAlpha)) {
             _MESSAGE("[CollisionAlpha] Invalid target alpha for actor %08X: %g", actor->formID, newAlpha);
             expectedState = ActorAlphaEpisodeState::Applying;
             episode->state.compare_exchange_strong(expectedState, ActorAlphaEpisodeState::Rejected);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include <deque>
 #include <optional>
 #include <shared_mutex>
+#include <cmath>
 
 #include <Physics/Collide/Shape/Convex/ConvexVertices/hkpConvexVerticesShape.h>
 #include <Physics/Collide/Shape/Convex/Capsule/hkpCapsuleShape.h>
@@ -2541,23 +2542,22 @@ std::unordered_map<Actor *, ActorAlphaData> g_dontCollideUntilStoppedCollidingAc
 
 // Actor::SetAlpha walks the actor's scene graph and mutates shader properties.
 // The player-proxy manifold callback may run during Havok's multithreaded update,
-// so defer that work to SKSE task processing outside the callback.
+// so keep the complete GetAlpha / SetAlpha transaction on the SKSE task queue.
 std::unordered_map<UInt32, ActorAlphaData> g_actorCollisionAlphaOverrides{};
 
-// The inherited VR headers label actor vtable entry E4 as a float-returning
-// GetAlpha, but that signature is not valid in Skyrim VR 1.4.15. Calling it can
-// leave an unrelated XMM value in the result and feed an enormous value to
-// Actor::SetAlpha. MiddleProcess::actorAlpha is the authoritative process
-// baseline. SetAlpha changes the render graph without updating this field, so
-// restoration must apply the current process baseline directly.
+bool IsValidActorAlpha(float alpha)
+{
+    return std::isfinite(alpha) && alpha >= 0.f && alpha <= 3.f; // Normal 0..1, optionally +2 for no fade.
+}
+
 bool TryGetActorAlpha(Actor *actor, float &alpha)
 {
-    if (!actor || !actor->processManager || !actor->processManager->middleProcess) {
+    if (!actor) {
         return false;
     }
 
-    alpha = actor->processManager->middleProcess->actorAlpha;
-    return alpha >= 0.f && alpha <= 3.f; // Normal 0..1, optionally +2 for no fade.
+    alpha = get_vfunc<_Actor_GetAlpha>(actor, 0xE4)(actor);
+    return IsValidActorAlpha(alpha);
 }
 
 struct UpdateActorCollisionAlphaTask : TaskDelegate
@@ -2587,11 +2587,21 @@ struct UpdateActorCollisionAlphaTask : TaskDelegate
             NiPointer<TESObjectREFR> refr;
             if (LookupREFRByHandle(actorHandle, refr)) {
                 if (Actor *actor = DYNAMIC_CAST(refr, TESObjectREFR, Actor)) {
-                    float processAlpha = -1.f;
-                    const float restoreAlpha = TryGetActorAlpha(actor, processAlpha)
-                        ? processAlpha
-                        : overrideIt->second.originalAlpha;
-                    get_vfunc<_Actor_SetAlpha>(actor, 0xE3)(actor, restoreAlpha);
+                    float currentAlpha = -1.f;
+                    if (!TryGetActorAlpha(actor, currentAlpha)) {
+                        _MESSAGE("[CollisionAlpha] Invalid alpha while restoring actor %08X: %g", actor->formID, currentAlpha);
+                    }
+                    else if (currentAlpha == overrideIt->second.overriddenAlpha) { // Only undo our own value.
+                        get_vfunc<_Actor_SetAlpha>(actor, 0xE3)(actor, overrideIt->second.originalAlpha);
+                    }
+                    else {
+                        _MESSAGE(
+                            "[CollisionAlpha] Actor %08X alpha changed externally; current=%g override=%g original=%g",
+                            actor->formID,
+                            currentAlpha,
+                            overrideIt->second.overriddenAlpha,
+                            overrideIt->second.originalAlpha);
+                    }
                 }
             }
             g_actorCollisionAlphaOverrides.erase(overrideIt);
@@ -2613,7 +2623,7 @@ struct UpdateActorCollisionAlphaTask : TaskDelegate
 
         float currentAlpha = -1.f;
         if (!TryGetActorAlpha(actor, currentAlpha)) {
-            _MESSAGE("[CollisionAlpha] Invalid process alpha for actor %08X: %g", actor->formID, currentAlpha);
+            _MESSAGE("[CollisionAlpha] Invalid alpha for actor %08X: %g", actor->formID, currentAlpha);
             return;
         }
 
@@ -2622,7 +2632,7 @@ struct UpdateActorCollisionAlphaTask : TaskDelegate
             newAlpha = 2.f + ((currentAlpha - 2.f) * Config::options.playerActorCollisionPhaseThroughAlphaMult);
         }
 
-        if (newAlpha < 0.f || newAlpha > 3.f) {
+        if (!IsValidActorAlpha(newAlpha)) {
             _MESSAGE("[CollisionAlpha] Invalid target alpha for actor %08X: %g", actor->formID, newAlpha);
             return;
         }


### PR DESCRIPTION
## Why

This PR is now a draft. The glowing-eye and actor-invisibility failure that
motivated it has been traced to NPC Spell Variance - Spell Variety AI 2.7.0,
not to a demonstrated PLANCK fault.

NPC Spell Variance installs its `ActorHook::UpdateCombat` thunk in Character
vtable slot `0xE4`. That is `UpdateCombat` on Skyrim SE, but `GetAlpha` on
Skyrim VR; VR's `UpdateCombat` slot is `0xE6`. The resulting signature and
return-value mismatch makes Skyrim VR `GetAlpha` return undefined values.
PLANCK exposes the defect when its collision phase-through path consumes that
value and writes the derived alpha.

The upstream bug is recorded here:

https://www.nexusmods.com/skyrimspecialedition/mods/132097?tab=bugs

## Draft hardening proposal

The code in this branch explores defenses that may still be useful on their
own merits:

- move PLANCK's temporary alpha mutation out of the Havok callback;
- retain the actor for each deferred transaction;
- bind Apply and Restore operations to one collision episode;
- validate alpha before consuming it;
- preserve a later alpha change made by Skyrim or another plugin.

These measures are not the root fix for the reported symptom. In particular,
rejecting a corrupt `GetAlpha` result can hide the presence of a broken hook
without repairing it. Defensive validation should not become a substitute for
fixing an identifiable producer fault.

The root fix is a runtime-aware NPC Spell Variance hook: `0xE4` for SSE and
`0xE6` for VR. Until that is released and exercised, this PR should remain a
draft while the independent value of the callback and lifetime hardening is
considered separately.

## What changed

- Queue actor-alpha mutation through SKSE task processing.
- Use Skyrim VR actor vtable entry E4 for `GetAlpha` and E3 for `SetAlpha`.
- Validate source, target and restore values.
- Retain a `NiPointer<TESObjectREFR>` for the phase-through episode and queued
  work.
- Serialize episode and cross-episode ownership.
- Restore only when the current value still matches PLANCK's own override.

## Safety and failure behaviour

Invalid alpha fails closed. That prevents PLANCK from propagating a corrupt
value, but it can also suppress the visual phase-through effect while the
producer remains broken. A later external alpha change is preserved rather
than overwritten during Restore.

## Validation

- Exact-head x64 Release compilation passed with Skyrim VR 1.4.15, SKSEVR,
  MSVC v145 and the locally available Havok SDK.
- `git diff --check` passed.
- The earlier queued implementation removed the reproducible glow/invisibility
  symptom in MGO RC3, but that observation is now understood as downstream
  containment of the NPC Spell Variance fault—not proof of PLANCK causation.
- The final E4/E3 and conditional-restore revision has compile validation only;
  no separate runtime pass is claimed.
