### PR TITLE
fix(physics): guard HIGGS filter refresh

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4241,6 +4241,21 @@ void UpdateGrabbedActorMovementState(Actor *actor, bool doGrabbedActorMovement)
     }
 }
 
+void SetHiggsBodyReportingQuality(bhkWorld *world, const NiPointer<bhkRigidBody> &body)
+{
+    if (!world || !world->world || !body || !body->hkBody) return;
+
+    hkpRigidBody *hkBody = body->hkBody;
+    auto reportingQuality = hkpCollidableQualityType::HK_COLLIDABLE_QUALITY_KEYFRAMED_REPORTING;
+    if (hkBody->getWorld() != world->world || hkBody->getQualityType() == reportingQuality) return;
+
+    BSWriteLocker lock(&world->worldLock);
+    if (hkBody->getWorld() != world->world || hkBody->getQualityType() == reportingQuality) return;
+
+    hkBody->setQualityType(reportingQuality);
+    bhkWorld_UpdateCollisionFilterOnWorldObject(world, body);
+}
+
 void UpdateHiggsInfo(bhkWorld *world)
 {
     NiPointer<bhkRigidBody> rightHand = (bhkRigidBody *)g_higgsInterface->GetHandRigidBody(false);
@@ -4253,23 +4268,10 @@ void UpdateHiggsInfo(bhkWorld *world)
     g_rightWeapon = rightWeapon;
     g_leftWeapon = leftWeapon;
 
-    if (rightWeapon && rightWeapon->hkBody->getQualityType() != hkpCollidableQualityType::HK_COLLIDABLE_QUALITY_KEYFRAMED_REPORTING) {
-        rightWeapon->hkBody->setQualityType(hkpCollidableQualityType::HK_COLLIDABLE_QUALITY_KEYFRAMED_REPORTING);
-        bhkWorld_UpdateCollisionFilterOnWorldObject(world, rightWeapon);
-    }
-    if (leftWeapon && leftWeapon->hkBody->getQualityType() != hkpCollidableQualityType::HK_COLLIDABLE_QUALITY_KEYFRAMED_REPORTING) {
-        leftWeapon->hkBody->setQualityType(hkpCollidableQualityType::HK_COLLIDABLE_QUALITY_KEYFRAMED_REPORTING);
-        bhkWorld_UpdateCollisionFilterOnWorldObject(world, leftWeapon);
-    }
-
-    if (rightHand && rightHand->hkBody->getQualityType() != hkpCollidableQualityType::HK_COLLIDABLE_QUALITY_KEYFRAMED_REPORTING) {
-        rightHand->hkBody->setQualityType(hkpCollidableQualityType::HK_COLLIDABLE_QUALITY_KEYFRAMED_REPORTING);
-        bhkWorld_UpdateCollisionFilterOnWorldObject(world, rightHand);
-    }
-    if (leftHand && leftHand->hkBody->getQualityType() != hkpCollidableQualityType::HK_COLLIDABLE_QUALITY_KEYFRAMED_REPORTING) {
-        leftHand->hkBody->setQualityType(hkpCollidableQualityType::HK_COLLIDABLE_QUALITY_KEYFRAMED_REPORTING);
-        bhkWorld_UpdateCollisionFilterOnWorldObject(world, leftHand);
-    }
+    SetHiggsBodyReportingQuality(world, rightWeapon);
+    SetHiggsBodyReportingQuality(world, leftWeapon);
+    SetHiggsBodyReportingQuality(world, rightHand);
+    SetHiggsBodyReportingQuality(world, leftHand);
 
     if (rightHand) {
         g_higgsCollisionLayer = GetCollisionLayer(rightHand->hkBody);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4250,7 +4250,9 @@ void SetHiggsBodyReportingQuality(bhkWorld *world, const NiPointer<bhkRigidBody>
     if (hkBody->getWorld() != world->world || hkBody->getQualityType() == reportingQuality) return;
 
     BSWriteLocker lock(&world->worldLock);
-    if (hkBody->getWorld() != world->world || hkBody->getQualityType() == reportingQuality) return;
+    hkpWorld *lockedWorld = world->world;
+    if (!lockedWorld || body->hkBody != hkBody || hkBody->getWorld() != lockedWorld ||
+        hkBody->getQualityType() == reportingQuality) return;
 
     hkBody->setQualityType(reportingQuality);
     bhkWorld_UpdateCollisionFilterOnWorldObject(world, body);


### PR DESCRIPTION
## Why

Rapid world transitions can leave a HIGGS hand or weapon rigid body attached
to a different Havok world while PLANCK refreshes its collision filter.
`UpdateHiggsInfo` also changed the body's quality and refreshed the filter
without holding that world's write lock. A Skyrim VR crash dump mapped the
failure to the right-hand refresh path after repeated `coc` transitions.

## What changed

Centralize the four HIGGS body refresh paths in a guarded helper. The helper:

- rejects null wrappers and bodies;
- requires exact membership in the target Havok world;
- acquires the target world's write lock;
- captures and requires a non-null locked world;
- verifies that the retained wrapper still owns the exact observed body;
- rechecks membership and current quality under the lock; and
- updates quality and the collision filter only while those invariants hold.

Bodies that have already left the target world are skipped, avoiding a stale
world mutation during transition teardown.

## Review correction

Independent review found that the first revision could accept a null/null world
comparison after waiting for the lock. Commit `ce7d269` closes that window by
requiring the locked world to remain non-null and revalidating exact wrapper,
body, and world identity before mutation. The corrected package is under
independent re-review.

## Validation

- Corrected x64 Release build passed with the proprietary Havok SDK available
  locally.
- `git diff --check origin/master...HEAD` passed.
- An earlier revision completed 40 focused transitions without a crash: ten
  repeats each of MarkarthUnderstoneKeep, WhiterunBreezehome,
  BleakFallsBarrow01, and EmbershardMine01.

The runtime pass predates the final null-world correction and is not claimed as
execution of commit `ce7d269`. A later broader route ended in a distinct
recurring AMD D3D11 worker crash with no PLANCK frames.
