### PR TITLE
fix(physics): avoid stale constraint restore

### DIFF
--- a/include/RE/bs_intrusive_ref_ptr.h
+++ b/include/RE/bs_intrusive_ref_ptr.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <Windows.h>
+
+#include <cstdint>
+#include <type_traits>
+#include <utility>
+
+// SKSE VR's legacy BSTSmartPointer is layout-only and does not decrement
+// BSIntrusiveRefCounted references. Use this owner for engine APIs that AddRef
+// an output parameter. It deliberately stays pointer-sized so it is ABI
+// compatible with the engine's output wrapper.
+template <class T, std::size_t RefCountOffset>
+class BSIntrusiveRefPtr
+{
+public:
+    T *ptr{ nullptr };
+
+    BSIntrusiveRefPtr() noexcept = default;
+    BSIntrusiveRefPtr(const BSIntrusiveRefPtr &) = delete;
+    BSIntrusiveRefPtr &operator=(const BSIntrusiveRefPtr &) = delete;
+
+    BSIntrusiveRefPtr(BSIntrusiveRefPtr &&other) noexcept :
+        ptr(std::exchange(other.ptr, nullptr))
+    {}
+
+    BSIntrusiveRefPtr &operator=(BSIntrusiveRefPtr &&other) noexcept
+    {
+        if (this != &other) {
+            Reset();
+            ptr = std::exchange(other.ptr, nullptr);
+        }
+        return *this;
+    }
+
+    ~BSIntrusiveRefPtr()
+    {
+        Reset();
+    }
+
+    void Reset() noexcept
+    {
+        T *object = std::exchange(ptr, nullptr);
+        auto *refCount = object ? reinterpret_cast<volatile LONG *>(
+            reinterpret_cast<std::uintptr_t>(object) + RefCountOffset) : nullptr;
+        if (object && InterlockedDecrement(refCount) == 0) {
+            using Destruct = void(*)(T *, std::uint32_t);
+            auto *vtable = *reinterpret_cast<std::uintptr_t **>(object);
+            reinterpret_cast<Destruct>(vtable[0])(object, 1);
+        }
+    }
+};

--- a/include/RE/havok_behavior.h
+++ b/include/RE/havok_behavior.h
@@ -26,6 +26,7 @@
 #include "skse64/GameReferences.h"
 
 #include "RE/havok.h"
+#include "RE/bs_intrusive_ref_ptr.h"
 #include "RE/misc.h"
 #include "havok_ref_ptr.h"
 
@@ -773,6 +774,12 @@ public:
 static_assert(offsetof(BSAnimationGraphManager, graphs) == 0x40);
 static_assert(offsetof(BSAnimationGraphManager, updateLock) == 0x98);
 
+using BSAnimationGraphManagerPtr = BSIntrusiveRefPtr<BSAnimationGraphManager, 0x08>;
+static_assert(sizeof(BSAnimationGraphManagerPtr) == sizeof(void *));
+static_assert(alignof(BSAnimationGraphManagerPtr) == alignof(void *));
+static_assert(!std::is_copy_constructible_v<BSAnimationGraphManagerPtr>);
+static_assert(std::is_nothrow_move_constructible_v<BSAnimationGraphManagerPtr>);
+
 struct hkbPoweredRagdollControlData
 {
     HK_ALIGN16(hkReal m_maxForce) = 50.f; // 00
@@ -988,8 +995,11 @@ inline hkbGeneratorOutput::TrackHeader *GetTrackHeader(hkbGeneratorOutput &gener
     return numTracks > trackId ? &(generatorOutput.m_tracks->m_trackHeaders[trackId]) : nullptr;
 }
 
-typedef bool(*_IAnimationGraphManagerHolder_GetAnimationGraphManagerImpl)(IAnimationGraphManagerHolder *_this, BSTSmartPointer<BSAnimationGraphManager> &a_out);
-inline bool GetAnimationGraphManager(Actor *actor, BSTSmartPointer<BSAnimationGraphManager> &out) {
+typedef bool(*_IAnimationGraphManagerHolder_GetAnimationGraphManagerImpl)(IAnimationGraphManagerHolder *_this, BSAnimationGraphManagerPtr &a_out);
+inline bool GetAnimationGraphManager(Actor *actor, BSAnimationGraphManagerPtr &out) {
+    // Some callers intentionally reuse the same local for a second query.
+    // Release the previous result before Skyrim overwrites it.
+    out.Reset();
     IAnimationGraphManagerHolder *animGraphManagerHolder = &actor->animGraphHolder;
     UInt64 *vtbl = *((UInt64 **)animGraphManagerHolder);
     return ((_IAnimationGraphManagerHolder_GetAnimationGraphManagerImpl)(vtbl[0x02]))(animGraphManagerHolder, out);

--- a/include/main.h
+++ b/include/main.h
@@ -44,6 +44,7 @@ struct ActiveRagdoll
     float avgStress = 0.f;
     float deltaTime = 0.f;
     RE::hkRefPtr<hkpEaseConstraintsAction> easeConstraintsAction = nullptr;
+    RE::hkRefPtr<hkaRagdollInstance> easedRagdoll = nullptr;
     std::unordered_map<hkpConstraintInstance *, std::pair<hkVector4, hkVector4>> originalConstraintPivots{};
     double stateChangedTime = 0.0;
     RagdollState state = RagdollState::Idle;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5084,11 +5084,15 @@ void PreDriveToPoseHook(hkbRagdollDriver *driver, hkReal deltaTime, const hkbCon
 
                 const auto *actionLayout = reinterpret_cast<const EaseConstraintsActionLayout *>(
                     static_cast<hkpEaseConstraintsAction *>(ragdoll->easeConstraintsAction));
-                bool canRestoreConstraints = true;
-                for (hkpConstraintInstance *constraint : driver->ragdoll->getConstraintArray()) {
-                    if (!constraint || !constraint->getData()) {
-                        canRestoreConstraints = false;
-                        break;
+                // Retaining the origin ragdoll keeps its constraints alive and
+                // prevents a replacement generation from reusing their addresses.
+                bool canRestoreConstraints = ragdoll->easedRagdoll.val() == driver->ragdoll;
+                if (canRestoreConstraints) {
+                    for (hkpConstraintInstance *constraint : driver->ragdoll->getConstraintArray()) {
+                        if (!constraint || !constraint->getData()) {
+                            canRestoreConstraints = false;
+                            break;
+                        }
                     }
                 }
                 if (canRestoreConstraints) {
@@ -5104,21 +5108,22 @@ void PreDriveToPoseHook(hkbRagdollDriver *driver, hkReal deltaTime, const hkbCon
 
                 if (canRestoreConstraints) {
                     hkpEaseConstraintsAction_restoreConstraints(ragdoll->easeConstraintsAction, 0.f);
-                }
-                ragdoll->easeConstraintsAction = nullptr;
+                    if (Config::options.loosenRagdollConstraintPivots) {
+                        for (hkpConstraintInstance *constraint : driver->ragdoll->getConstraintArray()) {
+                            if (constraint->getData()->getType() == hkpConstraintData::CONSTRAINT_TYPE_RAGDOLL) {
+                                hkpRagdollConstraintData *data = (hkpRagdollConstraintData *)constraint->getData();
 
-                if (Config::options.loosenRagdollConstraintPivots) {
-                    for (hkpConstraintInstance *constraint : driver->ragdoll->getConstraintArray()) {
-                        if (constraint->getData()->getType() == hkpConstraintData::CONSTRAINT_TYPE_RAGDOLL) {
-                            hkpRagdollConstraintData *data = (hkpRagdollConstraintData *)constraint->getData();
-
-                            if (auto it = ragdoll->originalConstraintPivots.find(constraint); it != ragdoll->originalConstraintPivots.end()) {
-                                data->m_atoms.m_transforms.m_transformA.m_translation = it->second.first;
-                                data->m_atoms.m_transforms.m_transformB.m_translation = it->second.second;
+                                if (auto it = ragdoll->originalConstraintPivots.find(constraint); it != ragdoll->originalConstraintPivots.end()) {
+                                    data->m_atoms.m_transforms.m_transformA.m_translation = it->second.first;
+                                    data->m_atoms.m_transforms.m_transformB.m_translation = it->second.second;
+                                }
                             }
                         }
                     }
                 }
+                ragdoll->easeConstraintsAction = nullptr;
+                ragdoll->originalConstraintPivots.clear();
+                ragdoll->easedRagdoll = nullptr;
             }
 
             if (!ragdoll->easeConstraintsAction) {
@@ -5127,6 +5132,7 @@ void PreDriveToPoseHook(hkbRagdollDriver *driver, hkReal deltaTime, const hkbCon
                 hkpEaseConstraintsAction_ctor(easeConstraintsAction, (const hkArray<hkpEntity *>&)(driver->ragdoll->getRigidBodyArray()), 0);
                 ragdoll->easeConstraintsAction = easeConstraintsAction; // must do this after ctor since this increments the refcount
                 hkReferencedObject_removeReference(ragdoll->easeConstraintsAction);
+                ragdoll->easedRagdoll = driver->ragdoll;
 
                 // Loosen constraint pivots first
                 if (Config::options.loosenRagdollConstraintPivots) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include <deque>
 #include <optional>
 #include <shared_mutex>
+#include <new>
 
 #include <Physics/Collide/Shape/Convex/ConvexVertices/hkpConvexVerticesShape.h>
 #include <Physics/Collide/Shape/Convex/Capsule/hkpCapsuleShape.h>
@@ -280,7 +281,7 @@ void UpdateCollisionFilterOnAllBones(Actor *actor)
     if (Actor_IsInRagdollState(actor)) return;
 
     bool hasRagdollInterface = false;
-    BSTSmartPointer<BSAnimationGraphManager> animGraphManager{ 0 }; // need to init this to 0 or we crash
+    BSAnimationGraphManagerPtr animGraphManager;
     if (GetAnimationGraphManager(actor, animGraphManager)) {
         BSAnimationGraphManager_HasRagdoll(animGraphManager.ptr, &hasRagdollInterface);
     }
@@ -3078,11 +3079,19 @@ void TryUpdateNPCState(Actor *actor, bool isShoved, bool wasJustRagdolled)
 
 hkaKeyFrameHierarchyUtility::Output g_stressOut[200]; // set in a hook during driveToPose(). Just reserve a bunch of space so it can handle any number of bones.
 
-hkArray<hkVector4> g_scratchHkArray{}; // We can't call the destructor of this ourselves, so this is a global array to be used at will and never deallocated.
+// Construct the scratch array in static storage but intentionally never destroy
+// it: Skyrim/Havok grows it, and DLL shutdown must not free game-owned memory.
+alignas(hkArray<hkVector4>) char g_scratchHkArrayStorage[sizeof(hkArray<hkVector4>)]{};
+
+hkArray<hkVector4> &GetScratchHkArray()
+{
+    static auto *scratch = ::new (g_scratchHkArrayStorage) hkArray<hkVector4>{};
+    return *scratch;
+}
 
 bool IsAddedToWorld(Actor *actor)
 {
-    BSTSmartPointer<BSAnimationGraphManager> animGraphManager{ 0 };
+    BSAnimationGraphManagerPtr animGraphManager;
     if (!GetAnimationGraphManager(actor, animGraphManager)) return false;
 
     BSAnimationGraphManager *manager = animGraphManager.ptr;
@@ -3129,7 +3138,7 @@ bool IsAddableToWorld(Actor *actor)
 
     if (IsTemporaryIgnoredActor(actor)) return false;
 
-    BSTSmartPointer<BSAnimationGraphManager> animGraphManager{ 0 };
+    BSAnimationGraphManagerPtr animGraphManager;
     if (!GetAnimationGraphManager(actor, animGraphManager)) return false;
 
     BSAnimationGraphManager *manager = animGraphManager.ptr;
@@ -3440,7 +3449,7 @@ bool AddRagdollToWorld(Actor *actor)
     if (!Config::options.processRagdolledActors && Actor_IsInRagdollState(actor)) return false;
 
     bool hasRagdollInterface = false;
-    BSTSmartPointer<BSAnimationGraphManager> animGraphManager{ 0 }; // need to init this to 0 or we crash
+    BSAnimationGraphManagerPtr animGraphManager;
     if (GetAnimationGraphManager(actor, animGraphManager)) {
         BSAnimationGraphManager_HasRagdoll(animGraphManager.ptr, &hasRagdollInterface);
     }
@@ -3535,7 +3544,7 @@ bool AddRagdollToWorld(Actor *actor)
 
 void CleanupActiveRagdollTracking(Actor *actor)
 {
-    BSTSmartPointer<BSAnimationGraphManager> animGraphManager{ 0 }; // need to init this to 0 or we crash
+    BSAnimationGraphManagerPtr animGraphManager;
     if (GetAnimationGraphManager(actor, animGraphManager)) {
         BSAnimationGraphManager *manager = animGraphManager.ptr;
         {
@@ -3576,7 +3585,7 @@ bool RemoveRagdollFromWorld(Actor *actor)
     if (!Config::options.processRagdolledActors && isInRagdollState) return false;
 
     bool hasRagdollInterface = false;
-    BSTSmartPointer<BSAnimationGraphManager> animGraphManager{ 0 }; // need to init this to 0 or we crash
+    BSAnimationGraphManagerPtr animGraphManager;
     if (GetAnimationGraphManager(actor, animGraphManager)) {
         BSAnimationGraphManager_HasRagdoll(animGraphManager.ptr, &hasRagdollInterface);
     }
@@ -3607,7 +3616,7 @@ void DisableOrEnableSyncOnUpdate(Actor *actor, bool disableElseEnable)
     if (Actor_IsInRagdollState(actor)) return;
 
     bool hasRagdollInterface = false;
-    BSTSmartPointer<BSAnimationGraphManager> animGraphManager{ 0 }; // need to init this to 0 or we crash
+    BSAnimationGraphManagerPtr animGraphManager;
     if (GetAnimationGraphManager(actor, animGraphManager)) {
         BSAnimationGraphManager_HasRagdoll(animGraphManager.ptr, &hasRagdollInterface);
     }
@@ -3646,7 +3655,7 @@ void RemoveActorFromWorldIfActive(Actor *actor)
 void EnableGravity(Actor *actor)
 {
     bool hasRagdollInterface = false;
-    BSTSmartPointer<BSAnimationGraphManager> animGraphManager{ 0 }; // need to init this to 0 or we crash
+    BSAnimationGraphManagerPtr animGraphManager;
     if (GetAnimationGraphManager(actor, animGraphManager)) {
         BSAnimationGraphManager_HasRagdoll(animGraphManager.ptr, &hasRagdollInterface);
     }
@@ -4452,8 +4461,8 @@ void ProcessHavokHitJobsHook(HavokHitJobs *havokHitJobs)
 
                 if (Config::options.resizePlayerCharController && convexVerticesShape) {
                     // Shrink convex charcontroller shape
-                    g_scratchHkArray.clear();
-                    hkArray<hkVector4> &verts = g_scratchHkArray;
+                    hkArray<hkVector4> &verts = GetScratchHkArray();
+                    verts.clear();
 
                     hkpConvexVerticesShape_getOriginalVertices(convexVerticesShape, verts);
 
@@ -5777,7 +5786,7 @@ struct RemoveNonRagdollRigidBodiesFromWorldTask : TaskDelegate
         NiPointer<TESObjectREFR> refr;
         if (LookupREFRByHandle(handle, refr)) {
             if (Actor *actor = DYNAMIC_CAST(refr, TESObjectREFR, Actor)) {
-                BSTSmartPointer<BSAnimationGraphManager> animGraphManager{ 0 };
+                BSAnimationGraphManagerPtr animGraphManager;
                 if (GetAnimationGraphManager(actor, animGraphManager)) {
                     BSAnimationGraphManager *manager = animGraphManager.ptr;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5084,18 +5084,18 @@ void PreDriveToPoseHook(hkbRagdollDriver *driver, hkReal deltaTime, const hkbCon
 
                 const auto *actionLayout = reinterpret_cast<const EaseConstraintsActionLayout *>(
                     static_cast<hkpEaseConstraintsAction *>(ragdoll->easeConstraintsAction));
-                std::unordered_set<hkpConstraintInstance *> currentConstraints;
                 bool canRestoreConstraints = true;
                 for (hkpConstraintInstance *constraint : driver->ragdoll->getConstraintArray()) {
                     if (!constraint || !constraint->getData()) {
                         canRestoreConstraints = false;
                         break;
                     }
-                    currentConstraints.insert(constraint);
                 }
                 if (canRestoreConstraints) {
                     for (hkpConstraintInstance *constraint : actionLayout->originalConstraints) {
-                        if (!constraint || currentConstraints.count(constraint) == 0) {
+                        if (!constraint || std::ranges::find(
+                            driver->ragdoll->getConstraintArray(), constraint) ==
+                            driver->ragdoll->getConstraintArray().end()) {
                             canRestoreConstraints = false;
                             break;
                         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5068,13 +5068,11 @@ void PreDriveToPoseHook(hkbRagdollDriver *driver, hkReal deltaTime, const hkbCon
             if (ragdoll->easeConstraintsAction) {
                 // Restore constraint limits from before we loosened them last time
 
-                // hkpEaseConstraintsAction keeps raw constraint pointers between
-                // frames.  Streaming can rebuild an actor's ragdoll while the
-                // driver and ActiveRagdoll entry remain alive, leaving the action
-                // with constraints that no longer belong to the current ragdoll.
-                // Calling restoreConstraints in that state dereferences stale
-                // constraint data.  Only restore when the current constraint set
-                // still contains every constraint captured by the action.
+                // hkpEaseConstraintsAction keeps raw constraint pointers but does
+                // not record which ragdoll supplied them. If the driver's ragdoll
+                // changes while this snapshot survives, restoring it would touch
+                // a different constraint generation. Require exact provenance and
+                // membership even though that replacement has not been reproduced.
                 struct EaseConstraintsActionLayout
                 {
                     std::byte base[0x48];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5068,7 +5068,43 @@ void PreDriveToPoseHook(hkbRagdollDriver *driver, hkReal deltaTime, const hkbCon
             if (ragdoll->easeConstraintsAction) {
                 // Restore constraint limits from before we loosened them last time
 
-                hkpEaseConstraintsAction_restoreConstraints(ragdoll->easeConstraintsAction, 0.f);
+                // hkpEaseConstraintsAction keeps raw constraint pointers between
+                // frames.  Streaming can rebuild an actor's ragdoll while the
+                // driver and ActiveRagdoll entry remain alive, leaving the action
+                // with constraints that no longer belong to the current ragdoll.
+                // Calling restoreConstraints in that state dereferences stale
+                // constraint data.  Only restore when the current constraint set
+                // still contains every constraint captured by the action.
+                struct EaseConstraintsActionLayout
+                {
+                    std::byte base[0x48];
+                    hkArray<hkpConstraintInstance *> originalConstraints;
+                };
+                static_assert(offsetof(EaseConstraintsActionLayout, originalConstraints) == 0x48);
+
+                const auto *actionLayout = reinterpret_cast<const EaseConstraintsActionLayout *>(
+                    static_cast<hkpEaseConstraintsAction *>(ragdoll->easeConstraintsAction));
+                std::unordered_set<hkpConstraintInstance *> currentConstraints;
+                bool canRestoreConstraints = true;
+                for (hkpConstraintInstance *constraint : driver->ragdoll->getConstraintArray()) {
+                    if (!constraint || !constraint->getData()) {
+                        canRestoreConstraints = false;
+                        break;
+                    }
+                    currentConstraints.insert(constraint);
+                }
+                if (canRestoreConstraints) {
+                    for (hkpConstraintInstance *constraint : actionLayout->originalConstraints) {
+                        if (!constraint || currentConstraints.count(constraint) == 0) {
+                            canRestoreConstraints = false;
+                            break;
+                        }
+                    }
+                }
+
+                if (canRestoreConstraints) {
+                    hkpEaseConstraintsAction_restoreConstraints(ragdoll->easeConstraintsAction, 0.f);
+                }
                 ragdoll->easeConstraintsAction = nullptr;
 
                 if (Config::options.loosenRagdollConstraintPivots) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -735,7 +735,7 @@ void ForEachRagdollDriver(BSAnimationGraphManager *graphManager, std::function<v
 
 void ForEachRagdollDriver(Actor *actor, std::function<void(hkbRagdollDriver *)> f)
 {
-    BSTSmartPointer<BSAnimationGraphManager> animGraphManager{ 0 };
+    BSAnimationGraphManagerPtr animGraphManager;
     if (GetAnimationGraphManager(actor, animGraphManager)) {
         ForEachRagdollDriver(animGraphManager.ptr, f);
     }
@@ -752,7 +752,7 @@ void ForEachAnimationGraph(BSAnimationGraphManager *graphManager, std::function<
 
 void ForEachAnimationGraph(Actor *actor, std::function<void(BShkbAnimationGraph *)> f)
 {
-    BSTSmartPointer<BSAnimationGraphManager> animGraphManager{ 0 };
+    BSAnimationGraphManagerPtr animGraphManager;
     if (GetAnimationGraphManager(actor, animGraphManager)) {
         ForEachAnimationGraph(animGraphManager.ptr, f);
     }


### PR DESCRIPTION
## Why

`hkpEaseConstraintsAction` retains raw constraint pointers between drive
updates, but the action itself records no provenance for the ragdoll generation
that produced them.

A retained crash investigation established the following:

- The failing path was
  `SkyrimVR+0B9F86F -> activeragdoll.dll!PreDriveToPoseHook (main.cpp:5072) -> DriveToPoseHook`.
- The saved `hkpEaseConstraintsAction` was non-null.
- One of its saved old constraints had a null `constraintData` pointer.
- The current ragdoll loop was operating on different, valid constraint
  addresses.

This establishes that PLANCK reached its restore path with a stale cross-frame
constraint snapshot and that calling the Havok restore routine without
provenance and membership checks was unsafe. An earlier guarded downstream
build subsequently passed the exact prior Riften -> Windhelm -> Solitude ->
Whiterun failure point twice, and this hardening has materially reduced crashes
in large modlists.

It does **not** establish:

- which game, plugin, or system replaced or invalidated the constraint
  generation;
- that PLANCK initiated that replacement or created the stale state;
- the exact lifecycle by which the `ActiveRagdoll` snapshot survived or
  diverged from the current ragdoll; or
- a deterministic standalone reproduction isolated from the large-modlist
  interaction.

PLANCK sits on a central gameplay path, so a fault produced elsewhere can
surface here. This PR is therefore fail-closed consumer-side hardening of an
observed unsafe restore, not a claim that PLANCK is the source of the upstream
lifecycle fault.

## What changed

- Retain the exact `hkaRagdollInstance` that originated each ease-action
  snapshot.
- Require identity with the driver's current ragdoll before restoring either
  constraints or saved pivots.
- Verify that every saved constraint is non-null and still belongs to the
  current ragdoll before calling the engine restore routine.
- Clear the action, pivot map, and retained origin together before taking a new
  snapshot.

Retaining the origin ragdoll keeps its constraint generation alive while the
snapshot exists, preventing allocator address reuse from making stale raw
constraint pointers appear current.

## Safety and scope

The consumed Skyrim VR/Havok SDK layout places the action's saved-constraint
array at offset `0x48`; that value is guarded by a compile-time ABI assertion.
Rejecting stale provenance or membership fails closed: neither engine
constraint restore nor pivot restore touches a different ragdoll, and the
reference-counted snapshot state is still released normally.

Ideally the producer-side lifecycle fault would be identified and fixed. This
guard may prevent that fault from becoming a crash without identifying its
source. The maintainer can decide whether that trade-off belongs upstream; the
downstream PLANCK patch will retain the hardening because of its practical
stability benefit.

## Validation

- The original downstream guard passed the exact previously failing Whiterun
  point twice on the retained route. This validates the observed failure point,
  not the precise producer-side lifecycle.
- Exact-head x64 Release `ClCompile` passed with Skyrim VR 1.4.15, SKSEVR,
  MSVC v145, and the locally available Havok SDK.
- The combined head containing this correction passes a clean x64 Release
  rebuild and link under the same toolchain.
- A compiler audit verifies the consumed saved-constraint offset is `0x48`.
- No deterministic ragdoll-replacement runtime pass is claimed for the final
  head.
